### PR TITLE
Migrating to 4.x express framework

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 var express = require('express')
 var fs = require('fs')
 var mysql = require('mysql')
+var session = require('express-session')
 
 var defaultOptions = {
 	debug: false,
@@ -19,7 +20,7 @@ function SessionStore(options, connection) {
 
 }
 
-SessionStore.prototype = new express.session.Store()
+SessionStore.prototype = new session.Store()
 SessionStore.prototype.constructor = SessionStore
 
 SessionStore.prototype.initialize = function() {


### PR DESCRIPTION
According to Express 4.x migration guide, most middleware (like session) is no longer bundled with Express. It's replaced by "express-session" that must be installed separately.
