### PR TITLE
Possibility to use connection pooling.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,10 +6,12 @@ var session = require('express-session')
 var defaultOptions = {
 	debug: false,
 	checkExpirationInterval: 900000,// 15 Minutes
+	keepAliveInterval: 30000,// 30 Seconds
 	expiration: 86400000,// 1 Day
 	autoReconnect: true,
 	reconnectDelay: 200,// 200 Milliseconds
-	maxReconnectAttempts: 25// Set to 0 for unlimited number of attempts.
+	maxReconnectAttempts: 25,// Set to 0 for unlimited number of attempts.
+	useConnectionPooling: false
 }
 
 function SessionStore(options, connection) {
@@ -31,7 +33,8 @@ SessionStore.prototype.initialize = function() {
 	if (!this.connection)
 		this.connect()
 
-	if (this.options.autoReconnect)
+	if (!this.options.useConnectionPooling &&
+		   this.options.autoReconnect)
 		this.listenForDisconnect()
 
 	this.sync()
@@ -40,8 +43,12 @@ SessionStore.prototype.initialize = function() {
 
 SessionStore.prototype.connect = function() {
 
-	this.connection = mysql.createConnection(this.options)
-	this.connection.connect()
+	if (this.options.useConnectionPooling) {
+		this.connection = mysql.createPool(this.options)
+	} else {
+		this.connection = mysql.createConnection(this.options)
+		this.connection.connect()
+	}
 
 }
 
@@ -116,6 +123,8 @@ SessionStore.prototype.sync = function(cb) {
 			}
 
 			self.setExpirationInterval()
+
+			self.setKeepAliveInterval()
 
 			cb && cb()
 
@@ -267,6 +276,35 @@ SessionStore.prototype.clearExpiredSessions = function(cb) {
 		cb && cb()
 
 	})
+
+}
+
+SessionStore.prototype.setKeepAliveInterval = function (interval) {
+
+	clearInterval(this._keepAliveInterval)
+
+	var self = this
+
+	this._keepAliveInterval = setInterval( function() {
+
+		if (self.options.useConnectionPooling) {
+
+		  self.connection.getConnection(function(err, conn) {
+
+				if(err) { return }
+
+				conn.ping()
+				conn.release()
+
+			})
+
+		} else {
+
+			self.connection.ping()
+
+		}
+
+  }, interval || this.options.keepAliveInterval)
 
 }
 

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,8 @@ var options = {
 	expiration: 86400000,// The maximum age of a valid session; milliseconds.
 	autoReconnect: true,// Whether or not to re-establish a database connection after a disconnect.
 	reconnectDelay: 200,// Time between reconnection attempts; milliseconds
-	maxReconnectAttempts: 25// Maximum number of reconnection attempts. Set to 0 for unlimited.
+	maxReconnectAttempts: 25,// Maximum number of reconnection attempts. Set to 0 for unlimited.
+	useConnectionPooling: false// Sets whether session should use connection pooling or not.
 }
 ```
 


### PR DESCRIPTION
This commit gives users the ability to use connection pooling. 

The main benefit is noticed with database restarts/disconnections. If a MySQL server is restarted, the error "Cannot enqueue Query after fatal error." is unrecoverable. When using Connection Pooling, as soon as the database is back online and a request is received, the session will reconnect.

Keep alive is also an interesting addition. Some servers, such as Google Compute Engine, may close a connection if it is inactive for too long.
