### PR TITLE
make DB table and (some) fields configurable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,9 @@ var defaultOptions = {
 	useConnectionPooling: false,// Whether or not to use connection pooling.
 	keepAlive: true,// Whether or not to send keep-alive pings on the database connection.
 	keepAliveInterval: 30000,// How frequently keep-alive pings will be sent; milliseconds.
+    tableName: 'sessions',
+    dataField: 'data',
+    idField: 'session_id'
 }
 
 function SessionStore(options, connection) {
@@ -86,15 +89,16 @@ SessionStore.prototype.sync = function(cb) {
 
 SessionStore.prototype.get = function(session_id, cb) {
 
-	var sql = 'SELECT `data` FROM `sessions` WHERE `session_id` = ? LIMIT 1'
+	var sql = 'SELECT `' + this.options.dataField + '` FROM `' + this.options.tableName + '` WHERE `' + this.options.idField + '` = ? LIMIT 1'
 	var params = [ session_id ]
+    var self = this
 
 	this.connection.query(sql, params, function(error, rows) {
 
 		if (error)
 			return cb(error, null)
 
-		var session = !!rows[0] ? JSON.parse(rows[0].data) : null
+		var session = !!rows[0] ? JSON.parse(rows[0][self.options.dataField]) : null
 
 		cb(null, session)
 
@@ -104,7 +108,7 @@ SessionStore.prototype.get = function(session_id, cb) {
 
 SessionStore.prototype.set = function(session_id, data, cb) {
 
-	var sql = 'REPLACE INTO `sessions` SET ?'
+	var sql = 'REPLACE INTO `' + this.options.tableName + '` SET ?'
 
 	var expires
 
@@ -118,9 +122,9 @@ SessionStore.prototype.set = function(session_id, data, cb) {
 
 	var params = {
 		session_id: session_id,
-		expires: expires,
-		data: JSON.stringify(data)
+		expires: expires
 	}
+    params[this.options.dataField] = JSON.stringify(data);
 
 	var self = this
 
@@ -137,7 +141,7 @@ SessionStore.prototype.set = function(session_id, data, cb) {
 
 SessionStore.prototype.destroy = function(session_id, cb) {
 
-	var sql = 'DELETE FROM `sessions` WHERE `session_id` = ? LIMIT 1'
+	var sql = 'DELETE FROM `' + this.options.tableName + '` WHERE `' + this.options.idField + '` = ? LIMIT 1'
 	var params = [ session_id ]
 
 	var self = this
@@ -163,7 +167,7 @@ SessionStore.prototype.destroy = function(session_id, cb) {
 
 SessionStore.prototype.length = function(cb) {
 
-	var sql = 'SELECT COUNT(*) FROM `sessions`'
+	var sql = 'SELECT COUNT(*) FROM `' + this.options.tableName + '`'
 
 	var self = this
 
@@ -190,7 +194,7 @@ SessionStore.prototype.length = function(cb) {
 
 SessionStore.prototype.clear = function(cb) {
 
-	var sql = 'DELETE FROM `sessions`'
+	var sql = 'DELETE FROM `' + this.options.tableName + '`'
 
 	this.connection.query(sql, function(error) {
 
@@ -205,7 +209,7 @@ SessionStore.prototype.clear = function(cb) {
 
 SessionStore.prototype.clearExpiredSessions = function(cb) {
 
-	var sql = 'DELETE FROM `sessions` WHERE `expires` < ?'
+	var sql = 'DELETE FROM `' + this.options.tableName + '` WHERE `expires` < ?'
 	var params = [ Math.round(Date.now() / 1000) ]
 
 	var self = this


### PR DESCRIPTION
I ran into a something where I had an existing session management running under php and wanted to re-use the existing database without having to change the legacy code.
This PR helps do that.
