### PR TITLE
add closeStore() method to facilitate in clean shutdown of express

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,9 +36,9 @@ function SessionStore(options, connection) {
 		console.log('Run your app with `DEBUG=express-mysql-session* node your-app.js` to have all logs and errors outputted to the console.')
 	}
 
-	var manager = new MySQLConnectionManager(options, connection || null)
+	this.manager = new MySQLConnectionManager(options, connection || null)
 
-	this.connection = manager.connection
+	this.connection = this.manager.connection
 
 	this.sync()
 
@@ -46,6 +46,20 @@ function SessionStore(options, connection) {
 
 SessionStore.prototype = new session.Store()
 SessionStore.prototype.constructor = SessionStore
+
+SessionStore.prototype.closeStore = function (cb) {
+
+  debug_log("closing store")
+
+  this.emit('disconnect')
+
+  this.clearExpirationInterval()
+
+  if (this.manager) {
+    this.manager.endConnection(cb)
+  }
+
+}
 
 SessionStore.prototype.setDefaultOptions = function() {
 


### PR DESCRIPTION
When shutting down express the expiration interval should be cleared and the DB connection/pool should be ended (along with clearing the keepalive interval the manager sets). This is dependent on the endConnection() method being present on the manager.

E.g. if you have the following setup:

SessionStore = require('express-mysql-session');
session_store = new SessionStore(session_config);

to cleanly end you would previously have had to do this:

session_store.clearExpirationInterval();
session_store.connection._MySQLConnectionManager.clearKeepAliveInterval();
session_store.connection.end();

and now you do:

session_store.closeStore();

this is dependent on pull request: https://github.com/chill117/mysql-connection-manager/pull/3
