### PR TITLE
Modify the behavior of SessionStore.prototype.set to be non-destructive.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -177,7 +177,7 @@ SessionStore.prototype.set = function(session_id, data, cb) {
 
 	data = JSON.stringify(data);
 
-	var sql = 'REPLACE INTO ?? (??, ??, ??) VALUES (?, ?, ?)';
+	var sql = 'INSERT INTO ?? (??, ??, ??) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE ?? = VALUES(??), ?? = VALUES(??)';
 
 	var params = [
 		this.options.schema.tableName,
@@ -186,7 +186,11 @@ SessionStore.prototype.set = function(session_id, data, cb) {
 		this.options.schema.columnNames.data,
 		session_id,
 		expires,
-		data
+		data,
+		this.options.schema.columnNames.expires,
+		this.options.schema.columnNames.expires,
+		this.options.schema.columnNames.data,
+		this.options.schema.columnNames.data
 	];
 
 	var self = this;


### PR DESCRIPTION
This commit modifies the SessionStore.prototype.set method to use MySQL's INSERT INTO ... ON DUPLICATE KEY UPDATE syntax for adding/updating the table row for a session, instead of REPLACE INTO. The latter can have undesired side effects when have a "cascade on delete" relationship with the sessions table.