### PR TITLE
Add option to prevent automatic connection closure

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ var defaultOptions = {
 	expiration: 86400000,// The maximum age of a valid session; milliseconds.
 	createDatabaseTable: true,// Whether or not to create the sessions database table, if one does not already exist.
 	connectionLimit: 1,// Number of connections when creating a connection pool
+	closeConnection: true,// Automatically close the MySQL connection when the store is closed
 	charset: 'utf8mb4_bin',
 	schema: {
 		tableName: 'sessions',
@@ -366,7 +367,7 @@ module.exports = function(session) {
 
 		this.clearExpirationInterval();
 
-		if (this.connection) {
+		if (this.connection && this.options.closeConnection) {
 			this.connection.end(cb);
 		} else {
 			cb && cb(null);


### PR DESCRIPTION
My application shares a MySQL connection with express-mysql-session and handles closing the connection by itself. I need to have express-mysql-session clear its expiry interval so the application doesn't hang, but I don't want my SQL connection to be closed when I call `store.close()`. This new option defaults to current behavior so this should not be a breaking change.