### PR TITLE
chore(package): bump express-session to 1.15.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "debug": "2.6.1",
     "depd": "1.1.0",
-    "express-session": "1.15.1",
+    "express-session": "1.15.3",
     "mysql": "2.13.0"
   },
   "devDependencies": {


### PR DESCRIPTION
until 1.15.3, `express-session` was marked vulnerable by tools like Snyk, due to its `debug` dependency (https://snyk.io/test/npm/express-session/1.15.2)