### PR TITLE
Add clearExpired option

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,9 @@ module.exports = function(session) {
 
 		var done = function() {
 
-			this.setExpirationInterval();
+			if (this.options.clearExpired) {
+				this.setExpirationInterval();
+			}
 
 			if (cb) {
 				cb.apply(undefined, arguments);
@@ -63,6 +65,8 @@ module.exports = function(session) {
 	util.inherits(MySQLStore, Store);
 
 	MySQLStore.prototype.defaultOptions = {
+		// Whether or not to automatically check for and clear expired sessions:
+		clearExpired: true,
 		// How frequently expired sessions will be cleared; milliseconds:
 		checkExpirationInterval: 900000,
 		// The maximum age of a valid session; milliseconds:

--- a/test/unit/options.js
+++ b/test/unit/options.js
@@ -1,0 +1,82 @@
+'use strict';
+
+var expect = require('chai').expect;
+
+var manager = require('../manager');
+var config = manager.config;
+var MySQLStore = manager.MySQLStore;
+
+describe('constructor options', function() {
+
+	before(function(done) {
+
+		manager.setUp(function(error, store) {
+
+			if (error) {
+				return done(error);
+			}
+
+			done();
+		});
+	});
+
+	after(manager.tearDown);
+
+	describe('clearExpired set to TRUE', function() {
+
+		it('should call clearExpiredSessions', function(done) {
+			var checkExpirationInterval = 45;
+
+			var sessionStore = new MySQLStore({
+				host: config.host,
+				port: config.port,
+				user: config.user,
+				password: config.password,
+				database: config.database,
+				checkExpirationInterval: checkExpirationInterval,
+				clearExpired: true
+			});
+
+			var called = false;
+
+			// Override the clearExpiredSessions method.
+			sessionStore.clearExpiredSessions = function() {
+				called = true;
+			};
+
+			setTimeout(function() {
+				expect(called).to.equal(true);
+				done();
+			}, checkExpirationInterval + 40);
+		});
+	});
+
+	describe('clearExpired set to FALSE', function() {
+
+		it('should not call clearExpiredSessions', function(done) {
+			var checkExpirationInterval = 45;
+
+			var sessionStore = new MySQLStore({
+				host: config.host,
+				port: config.port,
+				user: config.user,
+				password: config.password,
+				database: config.database,
+				checkExpirationInterval: checkExpirationInterval,
+				clearExpired: false
+			});
+
+			var called = false;
+
+			// Override the clearExpiredSessions method.
+			sessionStore.clearExpiredSessions = function() {
+				called = true;
+			};
+
+			setTimeout(function() {
+				expect(called).to.equal(false);
+				done();
+			}, checkExpirationInterval + 40);
+		});
+	});
+});

--- a/test/unit/options.js
+++ b/test/unit/options.js
@@ -1,12 +1,19 @@
 'use strict';
 
-var expect = require('chai').expect;
+var _ = require('underscore');
 
 var manager = require('../manager');
 var config = manager.config;
 var MySQLStore = manager.MySQLStore;
 
 describe('constructor options', function() {
+
+	var sessionStore;
+	afterEach(function() {
+		if (sessionStore) {
+			sessionStore.close();
+		}
+	});
 
 	before(function(done) {
 
@@ -25,58 +32,50 @@ describe('constructor options', function() {
 	describe('clearExpired set to TRUE', function() {
 
 		it('should call clearExpiredSessions', function(done) {
-			var checkExpirationInterval = 45;
 
-			var sessionStore = new MySQLStore({
+			sessionStore = new MySQLStore({
 				host: config.host,
 				port: config.port,
 				user: config.user,
 				password: config.password,
 				database: config.database,
-				checkExpirationInterval: checkExpirationInterval,
+				checkExpirationInterval: 1,
 				clearExpired: true
 			});
 
-			var called = false;
+			done = _.once(done);
 
 			// Override the clearExpiredSessions method.
 			sessionStore.clearExpiredSessions = function() {
-				called = true;
-			};
-
-			setTimeout(function() {
-				expect(called).to.equal(true);
 				done();
-			}, checkExpirationInterval + 40);
+			};
 		});
 	});
 
 	describe('clearExpired set to FALSE', function() {
 
 		it('should not call clearExpiredSessions', function(done) {
-			var checkExpirationInterval = 45;
 
-			var sessionStore = new MySQLStore({
+			sessionStore = new MySQLStore({
 				host: config.host,
 				port: config.port,
 				user: config.user,
 				password: config.password,
 				database: config.database,
-				checkExpirationInterval: checkExpirationInterval,
+				checkExpirationInterval: 1,
 				clearExpired: false
 			});
 
-			var called = false;
+			done = _.once(done);
 
 			// Override the clearExpiredSessions method.
 			sessionStore.clearExpiredSessions = function() {
-				called = true;
+				done(new Error('clearExpiredSessions method should NOT have been called'));
 			};
 
 			setTimeout(function() {
-				expect(called).to.equal(false);
 				done();
-			}, checkExpirationInterval + 40);
+			}, 30);
 		});
 	});
 });


### PR DESCRIPTION
I just added a simple check before calling setExpirationInterval(). If someone doesn't want express-mysql-session to clear sessions from the database by default, they can pass clearExpired: false as a constructor argument.