### PR TITLE
Move to latest mysql package: 2.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "debug": "4.1.1",
     "express-session": "1.17.0",
-    "mysql": "2.18.0",
+    "mysql": "2.18.1",
     "underscore": "1.9.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "debug": "4.1.1",
     "express-session": "1.17.0",
-    "mysql": "2.17.1",
+    "mysql": "2.18.0",
     "underscore": "1.9.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The current mysql package is 2.18.1. It has time sensitive updates for those using Amazon RDS. It would make sense to update express-mysql-session so as to not break existing installations using Amazon RDS.