### PR TITLE
Add optional support for json column data storage

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* v2.2.0:
+  * Add optional support for json column data storage
 * v2.1.5:
   * Updated dependencies
 * v2.1.4:

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ module.exports = function(session) {
 		debug.log('Creating sessions database table');
 
 		var fs = require('fs');
-		var schemaFilePath = path.join(__dirname, 'schema.sql');
+		var schemaFilePath = this.options.jsonData ? path.join(__dirname, 'schema-json.sql') : path.join(__dirname, 'schema.sql');
 
 		fs.readFile(schemaFilePath, 'utf-8', function(error, sql) {
 
@@ -180,7 +180,7 @@ module.exports = function(session) {
 			}
 
 			try {
-				var session = JSON.parse(row.data);
+				var session = typeof row.data === "string" ? JSON.parse(row.data) : row.data;
 			} catch (error) {
 				debug.error('Failed to parse data for session (' + session_id + ')');
 				debug.error(error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "express-mysql-session",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express-mysql-session",
   "description": "A MySQL session store for express.js",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "main": "index.js",
   "scripts": {
     "benchmarks": "./node_modules/.bin/mocha test/benchmarks/ --recursive --reporter spec --ui bdd",

--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,9 @@ var options = {
 	expiration: 86400000,
 	// Whether or not to create the sessions database table, if one does not already exist:
 	createDatabaseTable: true,
+	// Whether or not to create the data column as type JSON. Defaults to false which
+	// creates as medium text.
+	jsonData: false
 	// Number of connections when creating a connection pool:
 	connectionLimit: 1,
 	// Whether or not to end the database connection when the store is closed.

--- a/schema-json.sql
+++ b/schema-json.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS `sessions` (
+  `session_id` varchar(128) COLLATE utf8mb4_bin NOT NULL,
+  `expires` int(11) unsigned NOT NULL,
+  `data` json,
+  PRIMARY KEY (`session_id`)
+) ENGINE=InnoDB

--- a/test/manager.js
+++ b/test/manager.js
@@ -3,7 +3,6 @@
 var _ = require('underscore');
 var async = require('async');
 var session = require('express-session');
-var mysql = require('mysql');
 
 var config = require('./config');
 var fixtures = require('./fixtures');

--- a/test/unit/constructor.js
+++ b/test/unit/constructor.js
@@ -169,6 +169,37 @@ describe('constructor', function() {
 			});
 		});
 
+		describe('jsonData', function() {
+
+			it('should default to falsy', function(done) {
+
+				var options = _.extend({}, manager.config);
+
+				sessionStore = new MySQLStore(options);
+				done = _.once(done);
+
+				expect(sessionStore.options.jsonData).to.be.undefined;
+
+				setTimeout(function() {
+					done();
+				}, 30);
+			});
+
+			it('should be true if specified as true in the options', function(done) {
+
+				var options = _.extend({ jsonData: true }, manager.config);
+
+				sessionStore = new MySQLStore(options);
+				done = _.once(done);
+
+				expect(sessionStore.options.jsonData).to.be.true;
+
+				setTimeout(function() {
+					done();
+				}, 30);
+			});
+		});
+
 		describe('schema', function() {
 
 			it('should throw an error when defining unknown column(s)', function() {

--- a/test/unit/get.js
+++ b/test/unit/get.js
@@ -7,60 +7,76 @@ var manager = require('../manager');
 
 describe('get(session_id, cb)', function() {
 
-	before(manager.setUp);
-	after(manager.tearDown);
+	_.each([undefined, false, true], function(jsonData) {
 
-	describe('when a session exists', function() {
+		describe('when options.jsonData is set to ' + jsonData, function() {
 
-		var session_id;
-		var data;
-		beforeEach(function(done) {
-			var fixture = _.first(manager.fixtures.sessions);
-			session_id = fixture.session_id;
-			data = fixture.data;
-			manager.populateSession(fixture, done);
-		});
+			before(manager.tearDown);
+			before(function(done) {
+				manager.createInstance({ jsonData: jsonData }, done);
+			});
 
-		describe('and is not expired', function() {
+			after(manager.tearDown);
 
-			it('should return its session data', function(done) {
-				manager.sessionStore.get(session_id, function(error, session) {
-					if (error) return done(error);
-					expect(JSON.stringify(session)).to.equal(JSON.stringify(data));
-					done();
+			describe('when a session exists', function() {
+
+				var session_id;
+				var data;
+				beforeEach(function(done) {
+					var fixture = _.first(manager.fixtures.sessions);
+					session_id = fixture.session_id;
+					data = fixture.data;
+					manager.populateSession(fixture, done);
+				});
+
+				describe('and is not expired', function() {
+
+					it('should return its session data', function(done) {
+						manager.sessionStore.get(session_id, function(error, session) {
+							if (error) return done(error);
+							expect(typeof session).to.equal('object');
+							if (jsonData) {
+								expect(session).to.deep.equal(data);
+							} else {
+								expect(JSON.stringify(session)).to.equal(JSON.stringify(data));
+							}
+							done();
+						});
+					});
+				});
+
+				describe('and is expired', function() {
+
+					beforeEach(function(done) {
+						manager.expireSession(session_id, done);
+					});
+
+					it('should return NULL', function(done) {
+						manager.sessionStore.get(session_id, function(error, session) {
+							if (error) return done(error);
+							expect(session).to.equal(null);
+							done();
+						});
+					});
+				});
+			})
+
+			describe('when a session does not exist', function() {
+
+				beforeEach(manager.clearSessions);
+
+				it('should return NULL', function(done) {
+
+					var fixture = _.first(manager.fixtures.sessions);
+					var session_id = fixture.session_id;
+					manager.sessionStore.get(session_id, function(error, session) {
+						if (error) return done(error);
+						expect(session).to.equal(null);
+						done();
+					});
 				});
 			});
 		});
 
-		describe('and is expired', function() {
-
-			beforeEach(function(done) {
-				manager.expireSession(session_id, done);
-			});
-
-			it('should return NULL', function(done) {
-				manager.sessionStore.get(session_id, function(error, session) {
-					if (error) return done(error);
-					expect(session).to.equal(null);
-					done();
-				});
-			});
-		});
-	});
-
-	describe('when a session does not exist', function() {
-
-		beforeEach(manager.clearSessions);
-
-		it('should return NULL', function(done) {
-
-			var fixture = _.first(manager.fixtures.sessions);
-			var session_id = fixture.session_id;
-			manager.sessionStore.get(session_id, function(error, session) {
-				if (error) return done(error);
-				expect(session).to.equal(null);
-				done();
-			});
-		});
 	});
 });


### PR DESCRIPTION
This is a follow up to #91 with a draft of how the unit tests could be implemented to cover the JSON column changes introduced in that PR.

@chill117 - Thanks so much for writing this library 🎉 

Let me know what you think of how I am adding coverage of the `jsonData` flag.  I went with a dynamic test approach since I thought it would be good to cover the touch points broadly, though it may have caused testing in places where the flag doesn't matter.   I thought that might reduce repetition/verbosity in the test code, but let me know if you'd prefer to structure it differently and I'll update this PR.

Regarding your point about the two schema files: I too am torn about this. I don't like the repetition, but wrapping the SQL in some generator also seems a bit overly complex.  I am leaning towards "keep the two files and wait for a bigger change in the future that warrants the added complexity", but I could probably go either way, and if you want, I can experiment with a solution where the sql is dynamically generated.

