### PR TITLE
update underscore to fix CVE-2021-23358

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2011,9 +2011,9 @@
       }
     },
     "underscore": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.0.tgz",
-      "integrity": "sha512-21rQzss/XPMjolTiIezSu3JAjgagXKROtNrYFEOWK109qY1Uv2tVjPTZ1ci2HgvQDA16gHYSthQIJfB+XId/rQ=="
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "debug": "4.3.1",
     "express-session": "1.17.1",
     "mysql": "2.18.1",
-    "underscore": "1.12.0"
+    "underscore": "1.12.1"
   },
   "devDependencies": {
     "async": "3.2.0",


### PR DESCRIPTION
This one updates underscore from 1.12.0 to latest bugfix release 1.12.1 to fix an Arbitrary Code Execution vulnerability (rated high so far).

Please release a new version of your package too to allow all others to pickup this changes as you use explicit version pinning.

Thanks,
S. Seide