### PR TITLE
Add option to disable touch

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,8 @@ module.exports = function(session) {
 		connectionLimit: 1,
 		// Whether or not to end the database connection when the store is closed:
 		endConnectionOnClose: true,
+		// Make touch() a noop to cut down on db writes.
+		disableTouch: false,
 		charset: 'utf8mb4_bin',
 		schema: {
 			tableName: 'sessions',
@@ -250,6 +252,11 @@ module.exports = function(session) {
 	};
 
 	MySQLStore.prototype.touch = function(session_id, data, cb) {
+
+		if (this.options.disableTouch) {
+			debug.log('Skipping touch for session:', session_id);
+			return cb && cb();
+		}
 
 		debug.log('Touching session:', session_id);
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/chill117/express-mysql-session"
+    "url": "git://github.com/mmilleruva/express-mysql-session"
   },
   "author": {
     "name": "Charles Hill",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/mmilleruva/express-mysql-session"
+    "url": "git://github.com/chill117/express-mysql-session"
   },
   "author": {
     "name": "Charles Hill",


### PR DESCRIPTION
We were having significant scaling problems using express-mysql-session and were considering switching to a different express-session storage adapter. I noticed this adapter https://www.npmjs.com/package/connect-session-sequelize had a disable touch parameter. We have rolled this out in production and it reduced our session DB load by 75%. Obviously every case is unique, we have very long sessions and the session is modified and update  quite frequently already so this setting made sense for us.