### PR TITLE
change package from mysql to mysql2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var _ = require('underscore');
-var mysql = require('mysql');
+var mysql = require('mysql2');
 var path = require('path');
 var util = require('util');
 

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "dependencies": {
     "debug": "4.3.2",
-    "express-session": "1.17.2",
-    "mysql": "2.18.1",
+    "express-session": "1.17.3",
+    "mysql2": "2.3.3",
     "underscore": "1.13.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Also upgraded express-session to 1.17.3

The reason why I wanted to change the package is because using mysql2 with express-mysql-session doesn't work and has issues with changing session data (probably because it doesn't wait for the promise to resolve). But when just sending the connection params (it uses mysql) and we cannot have caching_sha2_password and this is a security issue.

Please make it work with mysql2 or just change the package.